### PR TITLE
Try to fix composer install by composer installers extender.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "jtl/go-prometrics-client",
-  "type": "library",
+  "type": "jtl-library",
   "description": "PHP-Client to use the JTL GoPrometrics Service",
   "license": "MIT",
   "require": {


### PR DESCRIPTION
Composer versucht wohl ab Version 2.0 Namespaces zu forcen, das Problem wurde hier genauer untersucht: https://github.com/oomphinc/composer-installers-extender/issues/26

Wir hatten genau die gleiche Problematik nach dem Update auf 2 in der POS, sobald man den type dann auf "namespace-name" ändert klappt das ganze auch unter 2 wieder.

@Milanowicz 